### PR TITLE
Move .btn css rules: index.css --> mycluster.css

### DIFF
--- a/src/Webpage/MyClusters/MyClusters.css
+++ b/src/Webpage/MyClusters/MyClusters.css
@@ -28,3 +28,18 @@
 .hive--private::after {
     content: "💩";
 }
+
+.btn 
+{ background: #2f3542;
+  color: white;
+  padding: 5px 10px;
+  margin: 3px;
+  border: none;
+  border-radius: 1000px;
+  cursor: pointer;
+  -moz-outline-radius: 1000px;
+}
+.btn i{
+  padding-right:0;
+}
+  


### PR DESCRIPTION
removed .btn css rule from .index as it cascaded down into other unwanted files and moved it to myclusters.css where it cannot cascade 